### PR TITLE
Resolves build errors caused by the type mismatch

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -76,7 +76,7 @@ void demo1()
     uint8_t data[240];
     uint64_t lastValue = 0;
     uint64_t currentValue = 0;
-    uint headPtr = 0;
+    uint32_t headPtr = 0;
     for (int i= 0; i<240; i++) {
         
         data[i] = 0; //(uint8_t) ( currentValue % (uint64_t)20 ) ;//  i%20;

--- a/main/ttgo.c
+++ b/main/ttgo.c
@@ -397,7 +397,7 @@ void fillBox(unsigned x, unsigned y, unsigned w, unsigned h, uint8_t pxRed, uint
 }
 
 
-void fillBox2(unsigned x, unsigned y, unsigned w, unsigned h, uint8_t pxRed, uint8_t pxGreen, uint8_t pxBlue, uint8_t * data, uint headPtr)
+void fillBox2(unsigned x, unsigned y, unsigned w, unsigned h, uint8_t pxRed, uint8_t pxGreen, uint8_t pxBlue, uint8_t * data, uint32_t headPtr)
 {
     //const unsigned y1 = /*83 + */y - h;
     //const unsigned y2 = /*83 + */y - 1;
@@ -425,7 +425,7 @@ void fillBox2(unsigned x, unsigned y, unsigned w, unsigned h, uint8_t pxRed, uin
     wrData(x2); 
 
     wrCmmd(ST7789_RAMWR);
-    uint i;
+    uint32_t i;
     for (i = 0; i < w*h; i++)
     {
         //vTaskDelay(10 / portTICK_PERIOD_MS);

--- a/main/ttgo.h
+++ b/main/ttgo.h
@@ -128,6 +128,6 @@
 
 void clearScreen(uint8_t pxRed, uint8_t pxGreen, uint8_t pxBlue);
 void fillBox(unsigned x, unsigned y, unsigned w, unsigned h, uint8_t pxRed, uint8_t pxGreen, uint8_t pxBlue);
-void fillBox2(unsigned x, unsigned y, unsigned w, unsigned h, uint8_t pxRed, uint8_t pxGreen, uint8_t pxBlue, uint8_t * data, uint headPtr);
+void fillBox2(unsigned x, unsigned y, unsigned w, unsigned h, uint8_t pxRed, uint8_t pxGreen, uint8_t pxBlue, uint8_t * data, uint32_t headPtr);
 unsigned displayStr(char *str, unsigned x, unsigned y, uint8_t pxRed, uint8_t pxGreen, uint8_t pxBlue, uint8_t size);
 void initTTGO();


### PR DESCRIPTION
First of all, thank you for the project. It helped me test my build environment with the board I had at hand. I encountered a slight issue with the build due to a uint type mismatch, which was the primary reason I created a fork. If you're still maintaining this project, I suggest the following changes in this pull request to make the project buildable out of the box:

Changes
- Changed the type of the headPtr variable from uint to int in main/main.c and main/ttgo.c.
- Updated the function signature for fillBox2 in main/ttgo.h to reflect the change of headPtr's type from uint to int.
- Modified the loop variable i to int inside fillBox2 function.